### PR TITLE
Fix: 서버 통신 무한 루프 해결

### DIFF
--- a/src/components/mypage/MyPosts.tsx
+++ b/src/components/mypage/MyPosts.tsx
@@ -52,7 +52,7 @@ const MyPosts = () => {
     };
 
     fetchData();
-  }, [user?.uid, posts]);
+  }, [user?.uid]);
 
   const onEdit = (data: PostData, id: string) => {
     navigate(`/community/edit`, { state: { data, id } });
@@ -64,6 +64,7 @@ const MyPosts = () => {
     if (confirm && user?.uid) {
       try {
         await deleteCommunity(`community/${postId}`);
+        setPosts((prev) => prev.filter((post) => post.id !== postId));
 
         const newTotal = posts.length - 1;
         const maxPage = Math.ceil(newTotal / itemsPerPage);


### PR DESCRIPTION
기존 의존성 배열에 posts가 서버 통신이 무한 루프에 빠짐,

해결 => 의존성 배열에서 posts 제거

onDelete함수에서 filter 메서드를 사용하여 기존 posts의 배열에서 삭제할 postId를 필터링하여 제거