### PR TITLE
커뮤니티 영역 모바일 반응형 작업 및 수정 작업

### DIFF
--- a/src/components/button/Button.module.scss
+++ b/src/components/button/Button.module.scss
@@ -1,73 +1,99 @@
 .ButtonStyle {
-    width: 100px;
-    height: 32px;
-    display: flex;
+  width: 100px;
+  height: 32px;
+  display: flex;
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  transition: 0.2s;
+  border-radius: 8px;
+  align-items: center;
+  justify-content: center;
+  background-color: black;
+  &:hover {
     color: white;
-    font-size: 14px;
-    cursor: pointer;
-    transition: 0.2s;
-    border-radius: 8px;
-    align-items: center;
-    justify-content: center;
-    background-color: black;
-    &:hover {
-        color: white;
-        background-color: #0f60ce;
-    }
+    background-color: #0f60ce;
+  }
+  @media (max-width: 768px) {
+    display: none;
+  }
 }
 
 .ButtonLgStyle {
-    width: 280px;
-    height: 60px;
-    display: flex;
+  width: 280px;
+  height: 60px;
+  display: flex;
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  transition: 0.2s;
+  border-radius: 8px;
+  align-items: center;
+  justify-content: center;
+  background-color: #0f60ce;
+  &:hover {
     color: white;
-    font-size: 14px;
-    cursor: pointer;
-    transition: 0.2s;
-    border-radius: 8px;
-    align-items: center;
-    justify-content: center;
-    background-color: #0f60ce;
-    &:hover {
-        color: white;
-        background-color: #0d4ca5;
-    }
+    background-color: #0d4ca5;
+  }
 }
 
 .ButtonCategory {
-    width: 70px;
-    height: 18px;
-    display: flex;
-    color: white;
-    font-size: 10px;
-    border-radius: 2px;
-    align-items: center;
-    justify-content: center;
-    background-color: #0F60CE;
+  width: 70px;
+  height: 18px;
+  display: flex;
+  color: white;
+  font-size: 10px;
+  border-radius: 2px;
+  align-items: center;
+  justify-content: center;
+  background-color: #0f60ce;
 }
 
 .ButtonEdit {
-    width: 60px;
-    height: 18px;
-    display: flex;
-    color: white;
-    font-size: 10px;
-    cursor: pointer;
-    border-radius: 2px;
-    align-items: center;
-    justify-content: center;
-    background-color: #0F60CE;
+  width: 60px;
+  height: 18px;
+  display: flex;
+  color: white;
+  font-size: 10px;
+  cursor: pointer;
+  border-radius: 2px;
+  align-items: center;
+  justify-content: center;
+  background-color: #0f60ce;
 }
 
 .ButtonDel {
-    width: 45px;
-    height: 18px;
-    display: flex;
+  width: 45px;
+  height: 18px;
+  display: flex;
+  color: white;
+  font-size: 10px;
+  cursor: pointer;
+  border-radius: 2%;
+  align-items: center;
+  justify-content: center;
+  background-color: #ff5050;
+}
+
+.ButtonCircle {
+  width: 50px;
+  height: 50px;
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  transition: 0.2s;
+  align-items: center;
+  border-radius: 100%;
+  justify-content: center;
+  background-color: black;
+  svg {
+    font-size: 20px;
+  }
+  &:hover {
     color: white;
-    font-size: 10px;
-    cursor: pointer;
-    border-radius: 2%;
-    align-items: center;
-    justify-content: center;
-    background-color: #FF5050;
+    background-color: #0f60ce;
+  }
+  @media (max-width: 768px) {
+    display: flex;
+  }
 }

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,7 +1,8 @@
 import styles from './Button.module.scss';
+import { FaPen } from '@react-icons/all-files/fa/FaPen';
 
 interface Props {
-  data: string;
+  data?: string;
 }
 
 const Button = ({ data }: Props) => {
@@ -24,4 +25,8 @@ const ButtonDel = ({ data }: Props) => {
   return <div className={styles.ButtonDel}>{data}</div>;
 };
 
-export { Button, ButtonCategory, ButtonEdit, ButtonDel, ButtonLg };
+const ButtonCircle = () => {
+  return <div className={styles.ButtonCircle}><FaPen /></div>;
+};
+
+export { Button, ButtonCategory, ButtonEdit, ButtonDel, ButtonLg, ButtonCircle };

--- a/src/components/community/CommunityCardItem.module.scss
+++ b/src/components/community/CommunityCardItem.module.scss
@@ -11,7 +11,12 @@
   border: 1px solid #cfcfcf;
   background-color: #ffffff;
   &:hover {
-  transform: scale(1.02);
+    transform: scale(1.02);
+  }
+  @media (max-width: 768px) {
+    max-width: 100%;
+    margin-left: 30px;
+    margin-right: 30px;
   }
 }
 
@@ -23,6 +28,11 @@
   img {
     width: 100%;
     height: 100%;
+    @media (max-width: 768px) {
+      width: auto;
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 }
 

--- a/src/components/community/CommunityCardList.module.scss
+++ b/src/components/community/CommunityCardList.module.scss
@@ -1,50 +1,95 @@
+.mainContainer {
+  position: relative;
+  .buttonCircle {
+    display: none;
+    @media (max-width: 768px) {
+      right: 20px;
+      bottom: 20px;
+      display: flex;
+      position: fixed;
+    }
+  }
+}
+
 .container {
-    width: 100%;
-    height: auto;
+  width: 100%;
+  height: auto;
+  display: grid;
+  flex-wrap: wrap;
+  margin-top: 30px;
+  column-gap: 20px;
+  justify-items: center;
+  justify-content: space-between;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  @media (max-width: 768px) {
     display: grid;
-    justify-items: center;
-    column-gap: 20px;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    flex-wrap: wrap;
-    margin-top: 30px;
-    justify-content: space-between;
+    grid-template-columns: 1fr;
+  }
+}
+
+.searchBoxTop {
+  display: none;
+  justify-content: center;
+  @media (max-width: 768px) {
+    display: flex;
+    margin: 30px 30px;
+  }
+}
+
+.searchBoxBottom {
+  display: flex;
+  justify-content: center;
+  @media (max-width: 768px) {
+    display: none;
+  }
 }
 
 .searchWritingBox {
-    width: 100%;
-    display: flex;
-    margin-top: 4px;
-    margin-bottom: 20px;
-    justify-content: space-between;
+  width: 100%;
+  display: flex;
+  margin-top: 4px;
+  margin-bottom: 20px;
+  justify-content: space-between;
 }
 
-.pagination{
-    display: flex;
-    justify-content: end;
+.pagination {
+  display: flex;
+  justify-content: end;
+  @media (max-width: 768px) {
+    justify-content: center;
+  }
 }
 
 .CommunityHeader {
-    gap: 6px;
-    display: flex;
-    justify-content: center;
+  gap: 6px;
+  display: flex;
+  justify-content: center;
+  @media (max-width: 768px) {
+    place-items: center;
+    display: grid;
+    margin: 0 30px;
+    grid-template-columns: 1fr 1fr;
   }
-  
-  .CategoryButton {
-    width: 148px;
-    height: 28px;
-    display: flex;
-    font-size: 12px;
-    cursor: pointer;
-    transition: 0.2s;
-    overflow: hidden;
-    border-radius: 4px;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid #e3e3e3;
-    background-color: #ffffff;
+}
+
+.CategoryButton {
+  width: 148px;
+  height: 28px;
+  display: flex;
+  font-size: 12px;
+  cursor: pointer;
+  transition: 0.2s;
+  overflow: hidden;
+  border-radius: 4px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #e3e3e3;
+  background-color: #ffffff;
+  @media (max-width: 768px) {
+    width: 100%;
   }
-  .Select {
-    color: #ffffff;
-    background-color: #0f60ce;
-  }
-  
+}
+.Select {
+  color: #ffffff;
+  background-color: #0f60ce;
+}

--- a/src/components/community/CommunityComment.module.scss
+++ b/src/components/community/CommunityComment.module.scss
@@ -1,6 +1,12 @@
 .border {
   margin-top: 30px;
-  border-top: 1px solid #cfcfcf;
+}
+
+.commentContainer {
+  @media (max-width: 768px) {
+      width: 100%;
+      padding: 0 20px;
+  }
 }
 
 .heartButton {
@@ -13,16 +19,17 @@
   align-items: center;
   border-radius: 50px;
   justify-content: center;
+  background-color: #ffffff;
   border: 1px solid #ff5050;
   svg {
     font-size: 18px;
     color: #ff5050;
   }
   .heartText {
-    margin-left: 4px;
     font-size: 14px;
-    padding-top: 3px;
     color: #ff5050;
+    padding-top: 3px;
+    margin-left: 4px;
   }
 }
 .Outline {
@@ -37,11 +44,23 @@
 
 .container {
   margin: 40px 34px;
+  @media (max-width: 768px) {
+    margin: 40px 0px;
+  }
 }
 
 .commentBox {
   display: flex;
+  border-radius: 4px;
   flex-direction: column;
+  padding: 20px 34px 10px;
+  background-color: #fcfcfc;
+  border: 1px solid #e1e1e1;
+  @media (max-width: 768px) {
+    padding: 0;
+    border: none;
+    background-color: #ffffff00;
+  }
 }
 
 .commentTitle {
@@ -57,6 +76,7 @@
   padding: 24px;
   border-radius: 4px;
   border: 1px solid #e1e1e1;
+  background-color: #ffffff;
   textarea {
     width: 100%;
     resize: none;
@@ -64,6 +84,9 @@
     font-size: 14px;
     border-style: none;
     font-family: 'GmarketSansMedium';
+    &:focus {
+      outline: none;
+    }
   }
 }
 

--- a/src/components/community/CommunityCommentItem.module.scss
+++ b/src/components/community/CommunityCommentItem.module.scss
@@ -10,15 +10,18 @@
 
 .replyIcon {
   font-size: 12px;
-  margin-right: 10px;
+  margin-right: 30px;
   color: rgb(188, 188, 188);
 }
 
 .replyIcons {
   font-size: 12px;
-  margin-right: 10px;
-  margin-left: 10px;
+  margin-right: 20px;
+  margin-left: 20px;
   color: rgb(188, 188, 188);
+  @media (max-width: 768px) {
+    margin-right: 0;
+  }
 }
 
 .commentTextBox {
@@ -30,6 +33,7 @@
   font-size: 14px;
   border-radius: 4px;
   border: 1px solid #e1e1e1;
+  background-color: #ffffff;
   textarea {
     width: 100%;
     resize: none;
@@ -37,6 +41,9 @@
     font-size: 14px;
     border-style: none;
     font-family: 'GmarketSansMedium';
+    &:focus {
+      outline: none;
+    }
   }
 }
 
@@ -86,25 +93,48 @@
   align-items: center;
   justify-content: end;
   .replyText {
-    // margin-bottom: 10px;
     cursor: pointer;
   }
-  .editText {
-    cursor: pointer;
-    color: #0f60ce;
-    // margin-bottom: 10px;
-  }
+}
+
+.editText {
+  cursor: pointer;
+  color: #0f60ce;
+}
+
+.editDelBox {
+  display: flex;
+  gap: 6px;
+}
+
+.userBoxMobile {
+  display: flex;
+  align-items: center;
 }
 
 .userBox {
   display: flex;
   font-size: 12px;
-  align-items: center;
   justify-content: end;
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+  .createdAtTextTop {
+    display: none;
+    @media (max-width: 768px) {
+      display: flex;
+      font-size: 10px;
+      color: #cdcdcd;
+      margin-top: 10px;
+      margin-left: 2px;
+    }
+  }
   .createdAtText {
     color: #b0b0b0;
+    @media (max-width: 768px) {
+      display: none;
+    }
   }
-
   .deleteText {
     cursor: pointer;
     color: #ff5050;
@@ -151,10 +181,6 @@
     width: 100%;
     height: 100%;
   }
-}
-
-.replyListBox {
-  // padding-top: 20px;
 }
 
 .editBox {

--- a/src/components/community/CommunityCommentItemReply.module.scss
+++ b/src/components/community/CommunityCommentItemReply.module.scss
@@ -1,7 +1,6 @@
 .container {
-  display: flex;
   width: 100%;
-  // margin-left: 30px;
+  display: flex;
 }
 
 .replyIcon {
@@ -31,13 +30,18 @@
   border-radius: 4px;
   margin-bottom: 10px;
   border: 1px solid #e1e1e1;
+  background-color: #FBFBFB;
   textarea {
     width: 100%;
     resize: none;
     display: flex;
     font-size: 14px;
     border-style: none;
+    background-color: #ffffff00;
     font-family: 'GmarketSansMedium';
+    &:focus {
+      outline: none;
+    }
   }
 }
 
@@ -47,12 +51,6 @@
   font-size: 12px;
   margin-bottom: 8px;
   justify-content: space-between;
-}
-
-.userBox {
-  display: flex;
-  margin-right: 2px;
-  align-items: center;
 }
 
 .usersImg {
@@ -111,14 +109,35 @@
   }
 }
 
+.userBoxMobile {
+  display: flex;
+  align-items: center;
+}
+
 .userBox {
   display: flex;
   font-size: 12px;
-  align-items: center;
   justify-content: end;
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+  .createdAtTextTop {
+    display: none;
+    @media (max-width: 768px) {
+      display: flex;
+      font-size: 10px;
+      color: #cdcdcd;
+      margin-top: 10px;
+      margin-left: 2px;
+    }
+  }
   .createdAtText {
     display: flex;
     color: #b0b0b0;
+    align-items: center;
+    @media (max-width: 768px) {
+      display: none;
+    }
   }
 
   .deleteText {

--- a/src/components/community/CommunityCommentItemReply.tsx
+++ b/src/components/community/CommunityCommentItemReply.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import styles from './CommunityCommentItemReply.module.scss';
+import { storage } from '@/firebase';
+import { useParams } from 'react-router-dom';
 import useUserStore from '@/store/useUsersStore';
+import { ConvertTimes } from '@/lib/util/convertTime';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { editReplies } from '@/lib/firebaseQueryCommunity';
-import { useParams } from 'react-router-dom';
-import { storage } from '@/firebase';
+import styles from './CommunityCommentItemReply.module.scss';
 import { ref, listAll, getDownloadURL } from 'firebase/storage';
-import { ConvertTimes } from '@/lib/util/convertTime';
+import { PROFILE_DEFAULT_IMG } from '@/lib/constants';
 
 const CommunityCommentItemReply = ({ data, val, setReplyList, onDel }: any) => {
   const value = data;
@@ -82,10 +83,19 @@ const CommunityCommentItemReply = ({ data, val, setReplyList, onDel }: any) => {
         <div className={styles.infoBox}>
           <div className={styles.userEditBox}>
             <div className={styles.userBox}>
-              <div className={styles.usersImg}>
-                <img src={imageUrl} alt="사용자 이미지" />
+              <div className={styles.userBoxMobile}>
+                <div className={styles.usersImg}>
+                  {imageUrl ? (
+                    <img src={imageUrl.toString()} alt="유저 이미지" />
+                  ) : (
+                    <img src={PROFILE_DEFAULT_IMG} alt="유저 이미지" />
+                  )}
+                </div>
+                <div>{value.userName}</div>
               </div>
-              <div>{value.userName}</div>
+              <div className={styles.createdAtTextTop}>
+                <ConvertTimes data={value.createdAt} />
+              </div>
             </div>
 
             <div
@@ -95,7 +105,7 @@ const CommunityCommentItemReply = ({ data, val, setReplyList, onDel }: any) => {
               <div className={styles.createdAtText}>
                 <ConvertTimes data={value.createdAt} />
               </div>
-              {user?.uid ? (
+              {data.userId === user?.uid ? (
                 <div className={styles.editBox}>
                   <div
                     className={styles.replyText}

--- a/src/components/community/CommunityDetail.module.scss
+++ b/src/components/community/CommunityDetail.module.scss
@@ -1,0 +1,9 @@
+.container {
+    @media (max-width: 768px) {
+        width: 100%;
+        padding: 40px 20px;
+        background-color: white;
+        border-top: 1px solid #cfcfcf;
+        border-bottom: 1px solid #cfcfcf;
+    }
+}

--- a/src/components/community/CommunityDetail.tsx
+++ b/src/components/community/CommunityDetail.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom';
+import styles from './CommunityDetail.module.scss';
 import CommunityTextViewer from './CommunityTextViewer';
 import useCommunityDataList from '@/hook/useCommunityDataList';
 import CommunityComment from '@/components/community/CommunityComment';
@@ -10,13 +11,29 @@ const CommunityDetail = () => {
   // 게시판 상세 내용 받아오기
   const { dataList } = useCommunityDataList(`/community`);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const value: any = dataList?.find((item: any) => item.id === currentUrl.id) || {};
+  interface Props {
+    category: string;
+    createdAt: string;
+    description: string;
+    id: string;
+    likes: [];
+    postImg: string;
+    title: string;
+    updateAt: string;
+    userId: string;
+    userImg: string;
+    userName: string;
+    views: number;
+  }
+
+  const value = dataList?.find((item: Props) => item.id === currentUrl.id) || {};
 
   return (
     <div>
-      <CommunityDetailHeader data={value} id={currentUrl} />
-      <CommunityTextViewer data={value} />
+      <div className={styles.container}>
+        <CommunityDetailHeader data={value} id={currentUrl} />
+        <CommunityTextViewer data={value} />
+      </div>
       <CommunityComment id={currentUrl} data={value} />
     </div>
   );

--- a/src/components/community/CommunityDetailLayout.module.scss
+++ b/src/components/community/CommunityDetailLayout.module.scss
@@ -1,6 +1,13 @@
-.Container {
-    padding: 25px;
-    border-radius: 4px;
-    background-color: white;
-    border: 1px solid #CFCFCF;
+.container {
+  padding: 25px;
+  border-radius: 4px;
+  background-color: white;
+  border: 1px solid #cfcfcf;
+  @media (max-width: 768px) {
+    border: none;
+    padding: 0px;
+    border-radius: 0;
+    background-color: #ffffff00;
+    border: 1px 0 1px 0 solid #cfcfcf;
+  }
 }

--- a/src/components/community/CommunityDetailLayout.tsx
+++ b/src/components/community/CommunityDetailLayout.tsx
@@ -7,7 +7,7 @@ interface Prop {
 
 const CommunityDetailLayout = ({children}: Prop) => {
   return (
-    <div className={styles.Container}>
+    <div className={styles.container}>
     {children}
     </div>
   )

--- a/src/components/community/CommunityEditTextEditor.module.scss
+++ b/src/components/community/CommunityEditTextEditor.module.scss
@@ -1,36 +1,71 @@
+.container {
+  @media (max-width: 768px) {
+    padding: 25px;
+  }
+}
+
 .inputBox {
-    width: 100%;
-    display: flex;
-    margin-bottom: 20px;
-    justify-content: space-between;
+  width: 100%;
+  display: flex;
+  margin-bottom: 20px;
+  justify-content: space-between;
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+}
+
+.reactQuill {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
 }
 
 .inputTitle {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
+}
+
+.inputSelect {
+  @media (max-width: 768px) {
+    margin-bottom: 20px;
+  }
+}
+
+.inputTextBox {
+  display: flex;
+  min-width: 1000px;
+  @media (max-width: 768px) {
+    min-width: 100%;
+  }
 }
 
 .textEditerSubmitButton {
-    display: flex;
-    margin: 30px 0 20px 0;
-    justify-content: center;
+  display: flex;
+  margin: 30px 0 20px 0;
+  justify-content: center;
 }
 
 .ButtonLgStyle {
-    width: 280px;
-    height: 50px;
-    display: flex;
+  width: 280px;
+  height: 50px;
+  display: flex;
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  transition: 0.2s;
+  margin-top: 40px;
+  border-radius: 8px;
+  border-style: none;
+  align-items: center;
+  justify-content: center;
+  background-color: #0f60ce;
+  font-family: 'GmarketSansMedium';
+  @media (max-width: 768px) {
+    width: 100%;
+    margin-top: 0px;
+  }
+  &:hover {
     color: white;
-    font-size: 14px;
-    cursor: pointer;
-    transition: 0.2s;
-    border-radius: 8px;
-    border-style: none;
-    align-items: center;
-    justify-content: center;
-    background-color: #0f60ce;
-    font-family: "GmarketSansMedium";
-    &:hover {
-        color: white;
-        background-color: #0d4ca5;
-    }
+    background-color: #0d4ca5;
+  }
 }

--- a/src/components/community/CommunityEditTextEditor.tsx
+++ b/src/components/community/CommunityEditTextEditor.tsx
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import ReactQuill from 'react-quill';
 import { Input, Select } from 'antd';
 import useUserStore from '@/store/useUsersStore';
 import { FormEvent, useEffect, useState } from 'react';
-import styles from './CommunityTextEditor.module.scss';
-import { useNavigate } from 'react-router-dom';
-import { useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
+import styles from './CommunityEditTextEditor.module.scss';
 import { editCommunity } from '@/lib/firebaseQueryCommunity';
-import ReactQuill from 'react-quill';
 
 const CommunityEditTextEditor = () => {
   const location = useLocation();
@@ -68,13 +67,14 @@ const CommunityEditTextEditor = () => {
   };
 
   return (
-    <div>
+    <div className={styles.container}>
       {loading ? <div>등록 중..</div> : ''}
       <form onSubmit={onSubmit}>
         <div className={styles.inputBox}>
           <div>
             <div className={styles.inputTitle}>카테고리</div>
             <Select
+              className={styles.inputSelect}
               defaultValue={category}
               style={{ width: 130 }}
               onChange={handleChange}
@@ -89,17 +89,18 @@ const CommunityEditTextEditor = () => {
               ]}
             />
           </div>
-          <div>
+          <div className={styles.inputTitleContainer}>
             <div className={styles.inputTitle}>제목</div>
             <Input
+              className={styles.inputTextBox}
               count={{ show: true, max: 50 }}
-              style={{ minWidth: '1000px', display: 'flex' }}
               defaultValue={title}
               onChange={handleChangeTitle}
             />
           </div>
         </div>
         <ReactQuill
+          className={styles.reactQuill}
           style={{ height: '400px' }}
           value={editorRef}
           onChange={handleChanges}

--- a/src/components/community/CommunityHeader.module.scss
+++ b/src/components/community/CommunityHeader.module.scss
@@ -1,10 +1,10 @@
-.CommunityHeader {
+.communityHeader {
   gap: 6px;
   display: flex;
   justify-content: center;
 }
 
-.CategoryButton {
+.categoryButton {
   width: 148px;
   height: 28px;
   display: flex;
@@ -18,7 +18,7 @@
   border: 1px solid #e3e3e3;
   background-color: #ffffff;
 }
-.Select {
+.select {
   color: #ffffff;
   background-color: #0f60ce;
 }

--- a/src/components/community/CommunityHeader.tsx
+++ b/src/components/community/CommunityHeader.tsx
@@ -18,13 +18,13 @@ const CommunityHeader = () => {
   }
 
   return (
-    <div className={styles.CommunityHeader}>
+    <div className={styles.communityHeader}>
       {CategoryList.map((item, index) => (
         <div
           className={
             index === currentTeb
-              ? `${styles.CategoryButton} ${styles.Select}`
-              : styles.CategoryButton
+              ? `${styles.categoryButton} ${styles.select}`
+              : styles.categoryButton
           }
           onClick={() => {
             setTabHandler(index);

--- a/src/components/community/CommunityTextEditor.module.scss
+++ b/src/components/community/CommunityTextEditor.module.scss
@@ -1,37 +1,71 @@
+.container {
+  @media (max-width: 768px) {
+    padding: 25px;
+  }
+}
+
 .inputBox {
-    width: 100%;
-    display: flex;
-    margin-bottom: 20px;
-    justify-content: space-between;
+  width: 100%;
+  display: flex;
+  margin-bottom: 20px;
+  justify-content: space-between;
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+}
+
+.reactQuill {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
 }
 
 .inputTitle {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
+}
+
+.inputSelect {
+  @media (max-width: 768px) {
+    margin-bottom: 20px;
+  }
+}
+
+.inputTextBox {
+  display: flex;
+  min-width: 1000px;
+  @media (max-width: 768px) {
+    min-width: 100%;
+  }
 }
 
 .textEditerSubmitButton {
-    display: flex;
-    margin: 30px 0 20px 0;
-    justify-content: center;
+  display: flex;
+  margin: 30px 0 20px 0;
+  justify-content: center;
 }
 
 .ButtonLgStyle {
-    margin-top: 40px;
-    width: 280px;
-    height: 50px;
-    display: flex;
+  width: 280px;
+  height: 50px;
+  display: flex;
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  transition: 0.2s;
+  margin-top: 40px;
+  border-radius: 8px;
+  border-style: none;
+  align-items: center;
+  justify-content: center;
+  background-color: #0f60ce;
+  font-family: 'GmarketSansMedium';
+  @media (max-width: 768px) {
+    width: 100%;
+    margin-top: 0px;
+  }
+  &:hover {
     color: white;
-    font-size: 14px;
-    cursor: pointer;
-    transition: 0.2s;
-    border-radius: 8px;
-    border-style: none;
-    align-items: center;
-    justify-content: center;
-    background-color: #0f60ce;
-    font-family: "GmarketSansMedium";
-    &:hover {
-        color: white;
-        background-color: #0d4ca5;
-    }
+    background-color: #0d4ca5;
+  }
 }

--- a/src/components/community/CommunityTextEditor.tsx
+++ b/src/components/community/CommunityTextEditor.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import ReactQuill from 'react-quill';
 import { Input, Select } from 'antd';
-import useUserStore from '@/store/useUsersStore';
+import 'react-quill/dist/quill.snow.css';
 import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useUserStore from '@/store/useUsersStore';
 import styles from './CommunityTextEditor.module.scss';
 import { addCommunity } from '@/lib/firebaseQueryCommunity';
-import { useNavigate } from 'react-router-dom';
-import ReactQuill from 'react-quill';
-import 'react-quill/dist/quill.snow.css';
 
 const CommunityTextEditor = () => {
   const { user } = useUserStore();
@@ -66,13 +66,14 @@ const CommunityTextEditor = () => {
   };
 
   return (
-    <div>
+    <div className={styles.container}>
       {loading ? <div>등록 중..</div> : ''}
       <form onSubmit={onSubmit}>
         <div className={styles.inputBox}>
           <div>
             <div className={styles.inputTitle}>카테고리</div>
             <Select
+              className={styles.inputSelect}
               defaultValue="자유게시판"
               style={{ width: 130 }}
               onChange={handleChange}
@@ -89,8 +90,8 @@ const CommunityTextEditor = () => {
           <div>
             <div className={styles.inputTitle}>제목</div>
             <Input
+              className={styles.inputTextBox}
               count={{ show: true, max: 50 }}
-              style={{ minWidth: '1000px', display: 'flex' }}
               value={title}
               onChange={handleChangeTitle}
             />
@@ -98,6 +99,7 @@ const CommunityTextEditor = () => {
         </div>
         <div>
           <ReactQuill
+            className={styles.reactQuill}
             style={{ height: '400px' }}
             value={editorRef}
             onChange={handleChanges}

--- a/src/components/mypage/DesktopIntroduce.tsx
+++ b/src/components/mypage/DesktopIntroduce.tsx
@@ -1,0 +1,119 @@
+import { ChangeEvent } from 'react';
+import styles from './Mypage.module.scss';
+import { IoIosCloseCircle } from '@react-icons/all-files/io/IoIosCloseCircle';
+import { PROFILE_DEFAULT_IMG } from '@/lib/constants';
+import useUserInfoChangeStore from '@/store/useUserInfoChangeStore';
+
+interface DesktopIntroduceProps {
+  props: {
+    onProfileUpload: (e: ChangeEvent<HTMLInputElement>) => void;
+    onDeleteProfileImg: () => void;
+    onChangeUserName: (e: ChangeEvent<HTMLInputElement>) => void;
+    onChangeText: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+    onEditModeOn: () => void;
+    onEditModeOff: () => void;
+    editText: string;
+    editMode: boolean;
+    isLoading: boolean;
+  };
+}
+
+const DesktopIntroduce = ({ props }: DesktopIntroduceProps) => {
+  const { imgUrl, userName } = useUserInfoChangeStore();
+
+  const {
+    onProfileUpload,
+    onDeleteProfileImg,
+    onChangeUserName,
+    onChangeText,
+    onEditModeOn,
+    onEditModeOff,
+    editText,
+    editMode,
+    isLoading,
+  } = props;
+
+  return (
+    <div className={styles.intro__container}>
+      <div className={styles.intro__profile__img}>
+        <img
+          src={imgUrl || PROFILE_DEFAULT_IMG}
+          alt="프로필 이미지"
+          width={162}
+          height={162}
+        />
+        {editMode ? (
+          <>
+            <label className={styles.intro__profile__img__edit}>
+              이미지
+              <br />
+              변경하기
+              <input type="file" accept="image/*" onChange={onProfileUpload} />
+            </label>
+            <button type="button" onClick={onDeleteProfileImg}>
+              <IoIosCloseCircle size={24} />
+            </button>
+          </>
+        ) : (
+          <></>
+        )}
+      </div>
+      <div className={styles.intro__info}>
+        <div
+          className={`${styles.intro__info__name} ${
+            editMode ? styles.editModeOn : styles.editModeOff
+          }`}
+        >
+          {editMode ? (
+            <>
+              <input
+                type="text"
+                value={userName as string}
+                onChange={onChangeUserName}
+                placeholder="최대 8글자입니다."
+                maxLength={8}
+                required
+              />
+            </>
+          ) : (
+            <>{userName}</>
+          )}
+        </div>
+        <div
+          className={`${styles.intro__info__talk} ${
+            editMode ? styles.editModeOn : styles.editModeOff
+          }`}
+        >
+          {editMode ? (
+            <>
+              <textarea
+                value={editText}
+                onChange={onChangeText}
+                placeholder="최대 300자 입니다."
+                maxLength={300}
+                required
+              />
+              <div>{editText.length} / 300</div>
+            </>
+          ) : (
+            <>{editText}</>
+          )}
+        </div>
+      </div>
+      <div className={styles.intro__info__edit}>
+        <button
+          type="button"
+          className={`${styles.intro__info__edit__btn} ${
+            editMode ? styles.editModeOn : styles.editModeOff
+          }`}
+          onClick={editMode ? onEditModeOff : onEditModeOn}
+          disabled={isLoading}
+        >
+          <span>{editMode ? '저장하기' : '프로필 편집'}</span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DesktopIntroduce;

--- a/src/components/mypage/Introduce.tsx
+++ b/src/components/mypage/Introduce.tsx
@@ -1,5 +1,4 @@
 import useUserStore from '@/store/useUsersStore';
-import styles from './Mypage.module.scss';
 import { ChangeEvent, useEffect, useState } from 'react';
 import {
   ref,
@@ -13,8 +12,9 @@ import { updateProfile } from 'firebase/auth';
 import { PROFILE_DEFAULT_IMG, STORAGE_DOWNLOAD_URL } from '@/lib/constants';
 import useUserInfoChangeStore from '@/store/useUserInfoChangeStore';
 import { getDocument, setDocument } from '@/lib/firebaseQuery';
-import { IoIosCloseCircle } from '@react-icons/all-files/io/IoIosCloseCircle';
 import useCalculateInnerWidth from '@/hook/useCalculateInnerWidth';
+import DesktopIntroduce from './DesktopIntroduce';
+import MobileIntroduce from './MobileIntroduce';
 
 const Introduce = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -148,90 +148,26 @@ const Introduce = () => {
     setImgUrl(PROFILE_DEFAULT_IMG);
   };
 
+  const props = {
+    onProfileUpload,
+    onDeleteProfileImg,
+    onChangeUserName,
+    onChangeText,
+    onEditModeOn,
+    onEditModeOff,
+    editText,
+    editMode,
+    isLoading,
+  };
+
   return (
-    <div className={styles.intro__container}>
-      <div className={styles.intro__profile__img}>
-        <img
-          src={imgUrl || PROFILE_DEFAULT_IMG}
-          alt="프로필 이미지"
-          width={windowWidth <= 768 ? 80 : 162}
-          height={windowWidth <= 768 ? 80 : 162}
-        />
-        {editMode ? (
-          <>
-            <label className={styles.intro__profile__img__edit}>
-              이미지
-              <br />
-              변경하기
-              <input type="file" accept="image/*" onChange={onProfileUpload} />
-            </label>
-            <button type="button" onClick={onDeleteProfileImg}>
-              <IoIosCloseCircle size={windowWidth <= 768 ? 18 : 24} />
-            </button>
-          </>
-        ) : (
-          <></>
-        )}
-      </div>
-      <div className={styles.intro__info}>
-        <div
-          className={`${styles.intro__info__name} ${
-            editMode ? styles.editModeOn : styles.editModeOff
-          }`}
-        >
-          {editMode ? (
-            <>
-              <input
-                type="text"
-                value={userName as string}
-                onChange={onChangeUserName}
-                placeholder="최대 8글자입니다."
-                maxLength={8}
-                required
-              />
-            </>
-          ) : (
-            <>{userName}</>
-          )}
-        </div>
-        <div
-          className={`${styles.intro__info__talk} ${
-            editMode ? styles.editModeOn : styles.editModeOff
-          }`}
-        >
-          {editMode ? (
-            <>
-              <textarea
-                value={editText}
-                onChange={onChangeText}
-                placeholder="최대 300자 입니다."
-                maxLength={300}
-                required
-              />
-              <div>{editText.length} / 300</div>
-            </>
-          ) : (
-            <>{editText}</>
-          )}
-        </div>
-      </div>
-      <div className={styles.intro__info__edit}>
-        <button
-          type="button"
-          className={`${styles.intro__info__edit__btn} ${
-            editMode ? styles.editModeOn : styles.editModeOff
-          }`}
-          onClick={editMode ? onEditModeOff : onEditModeOn}
-          disabled={isLoading}
-        >
-          {windowWidth <= 768 ? (
-            <span>{editMode ? '저장' : '편집'}</span>
-          ) : (
-            <span>{editMode ? '저장하기' : '프로필 편집'}</span>
-          )}
-        </button>
-      </div>
-    </div>
+    <>
+      {windowWidth <= 768 ? (
+        <MobileIntroduce props={props} />
+      ) : (
+        <DesktopIntroduce props={props} />
+      )}
+    </>
   );
 };
 

--- a/src/components/mypage/MobileIntroduce.tsx
+++ b/src/components/mypage/MobileIntroduce.tsx
@@ -1,0 +1,123 @@
+import { ChangeEvent } from 'react';
+import styles from './Mypage.module.scss';
+import { IoCloseSharp } from '@react-icons/all-files/io5/IoCloseSharp';
+import { PROFILE_DEFAULT_IMG } from '@/lib/constants';
+import useUserInfoChangeStore from '@/store/useUserInfoChangeStore';
+
+interface DesktopIntroduceProps {
+  props: {
+    onProfileUpload: (e: ChangeEvent<HTMLInputElement>) => void;
+    onDeleteProfileImg: () => void;
+    onChangeUserName: (e: ChangeEvent<HTMLInputElement>) => void;
+    onChangeText: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+    onEditModeOn: () => void;
+    onEditModeOff: () => void;
+    editText: string;
+    editMode: boolean;
+    isLoading: boolean;
+  };
+}
+
+const MobileIntroduce = ({ props }: DesktopIntroduceProps) => {
+  const { imgUrl, userName } = useUserInfoChangeStore();
+
+  const {
+    onProfileUpload,
+    onDeleteProfileImg,
+    onChangeUserName,
+    onChangeText,
+    onEditModeOn,
+    onEditModeOff,
+    editText,
+    editMode,
+    isLoading,
+  } = props;
+
+  return (
+    <div className={styles.intro__container}>
+      <div className={styles.intro__profile__img}>
+        <img
+          src={imgUrl || PROFILE_DEFAULT_IMG}
+          alt="프로필 이미지"
+          width={80}
+          height={80}
+        />
+        {editMode ? (
+          <>
+            <label className={styles.intro__profile__img__edit}>
+              이미지
+              <br />
+              변경하기
+              <input type="file" accept="image/*" onChange={onProfileUpload} />
+            </label>
+            <button type="button" onClick={onDeleteProfileImg}>
+              <IoCloseSharp size={18} color="#fff" />
+            </button>
+          </>
+        ) : (
+          <></>
+        )}
+      </div>
+      <div className={styles.intro__info}>
+        <div
+          className={`${styles.intro__info__name} ${
+            editMode ? '' : styles.editModeOff
+          }`}
+        >
+          {editMode ? (
+            <>
+              <input
+                type="text"
+                value={userName as string}
+                onChange={onChangeUserName}
+                placeholder="최대 8글자입니다."
+                maxLength={8}
+                required
+              />
+            </>
+          ) : (
+            <>{userName}</>
+          )}
+        </div>
+        <div
+          className={`${styles.intro__info__talk} ${
+            editMode ? styles.editModeOn : styles.editModeOff
+          }`}
+        >
+          {editMode ? (
+            <>
+              <textarea
+                value={editText}
+                onChange={onChangeText}
+                placeholder="최대 300자 입니다."
+                maxLength={300}
+                required
+              />
+              <div>{editText.length} / 300</div>
+            </>
+          ) : (
+            <>{editText}</>
+          )}
+        </div>
+      </div>
+      <div
+        className={`${styles.intro__info__edit} ${
+          editMode ? styles.editModeOn : ''
+        }`}
+      >
+        <button
+          type="button"
+          className={`${styles.intro__info__edit__btn} ${
+            editMode ? styles.editModeOn : styles.editModeOff
+          }`}
+          onClick={editMode ? onEditModeOff : onEditModeOn}
+          disabled={isLoading}
+        >
+          <span>{editMode ? '저장' : '편집'}</span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MobileIntroduce;

--- a/src/components/mypage/Mycard.tsx
+++ b/src/components/mypage/Mycard.tsx
@@ -154,8 +154,6 @@ const Mycard = () => {
     }
   }
 
-  console.log(index);
-
   const onCloseOverlay = useCallback(() => {
     if (isAlert === true) {
       setIsAlert(false);

--- a/src/components/mypage/Mypage.module.scss
+++ b/src/components/mypage/Mypage.module.scss
@@ -22,10 +22,11 @@
     background: #fff;
     display: flex;
     align-items: center;
-    padding-left: 20px;
+    padding: 0 20px;
 
     @media (max-width: 769px) {
-      height: 136px;
+      height: 187px;
+      margin-top: 21px;
     }
   }
 
@@ -42,6 +43,7 @@
     @media (max-width: 769px) {
       width: 80px;
       height: 80px;
+      top: -83px;
     }
 
     img {
@@ -53,6 +55,7 @@
       @media (max-width: 769px) {
         width: 80px;
         height: 80px;
+        background: #fff;
       }
     }
 
@@ -60,7 +63,16 @@
       padding: 0;
 
       @media (max-width: 769px) {
-        margin-right: -14px;
+        padding: 0;
+        background: black;
+        border-radius: 50%;
+        width: 18px;
+        height: 18px;
+        border: 1px solid #fff;
+        z-index: 11;
+        display: flex;
+        justify-content: center;
+        align-items: center;
       }
     }
 
@@ -95,10 +107,13 @@
     justify-content: center;
     gap: 15px;
     width: 100%;
-    height: 100%;
+    height: auto;
 
     @media (max-width: 769px) {
       gap: 8px;
+      position: relative;
+      left: -108px;
+      margin-top: 28px;
     }
 
     &__name {
@@ -111,23 +126,32 @@
 
       @media (max-width: 769px) {
         font-size: 24px;
-        width: 50%;
+        max-width: 350px;
+        width: 80vw;
+        margin-top: 28px;
       }
     }
 
-    .editModeOn input {
+    input {
       border: none;
       outline: none;
       border-bottom: 1px solid #000;
-      padding-bottom: 4px;
 
       @media (max-width: 769px) {
         width: 100%;
+        background-color: transparent;
+        color: #000;
+        font-family: Gmarket Sans;
+        font-size: 24px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: normal;
+        padding: 0;
       }
     }
 
     &__talk {
-      height: 33px;
+      height: 56px;
       flex-shrink: 0;
       color: #000;
       font-family: Gmarket Sans;
@@ -138,11 +162,12 @@
       white-space: pre-wrap;
       display: flex;
       width: 100%;
-      gap: 10px;
 
       @media (max-width: 769px) {
         line-height: 18px;
         overflow: auto;
+        display: flex;
+        flex-direction: column;
       }
 
       div {
@@ -150,12 +175,20 @@
         height: 70px;
         align-items: flex-end;
         width: 92px;
+
+        @media (max-width: 769px) {
+          height: auto;
+          width: 100%;
+          justify-content: flex-end;
+        }
       }
     }
 
     .editModeOn {
       @media (max-width: 769px) {
-        height: 100px;
+        height: 56px;
+        max-width: 350px;
+        width: 80vw;
       }
     }
 
@@ -173,9 +206,9 @@
 
   &__info__edit {
     position: relative;
-    right: 19px;
+    padding-top: 15px;
     height: 100%;
-    top: 15px;
+    right: 158px;
 
     &__btn {
       width: 80px;

--- a/src/lib/firebaseQueryCommunity.ts
+++ b/src/lib/firebaseQueryCommunity.ts
@@ -13,7 +13,7 @@ import {
 interface DataObject {
   uid?: string;
   views?: number;
-  likes?: [];
+  likes?: string[];
   title?: string;
   postId?: string;
   userId?: string;

--- a/src/lib/util/convertTime.ts
+++ b/src/lib/util/convertTime.ts
@@ -1,8 +1,9 @@
 interface reverseObject {
-  data: string;
+  data?: string;
 }
 
 export const ConvertTime = (value: reverseObject) => {
+  if (!value.data) return '';
   const utcDate = new Date(value.data);
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
@@ -10,13 +11,12 @@ export const ConvertTime = (value: reverseObject) => {
     day: 'numeric',
     timeZone: 'Asia/Seoul', // 시간대를 서울로 설정
   };
-
   const formattedKoreanDate = utcDate.toLocaleDateString('ko-KR', options);
-
   return formattedKoreanDate;
 };
 
 export const ConvertTimes = (value: reverseObject) => {
+  if (!value.data) return '';
   const utcDate = new Date(value.data);
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
@@ -27,8 +27,6 @@ export const ConvertTimes = (value: reverseObject) => {
     second: 'numeric',
     timeZone: 'Asia/Seoul', // 시간대를 서울로 설정
   };
-
   const formattedKoreanDate = utcDate.toLocaleDateString('ko-KR', options);
-
   return formattedKoreanDate;
 };

--- a/src/lib/util/fetchProfileImages.ts
+++ b/src/lib/util/fetchProfileImages.ts
@@ -1,0 +1,14 @@
+import { ref, listAll, getDownloadURL } from 'firebase/storage';
+import { storage } from '@/firebase';
+
+const FetchProfileImages = async (userId: string) => {
+  if (!userId) return [];
+  const fileRef = ref(storage, `${userId}`); // fileRef의 타입을 명시적으로 지정
+  const result = await listAll(fileRef);
+  const valData = await Promise.all(
+    result.items.map(async (item) => await getDownloadURL(item)),
+  );
+  return valData;
+};
+
+export { FetchProfileImages };

--- a/src/pages/community/CommunityLayout.module.scss
+++ b/src/pages/community/CommunityLayout.module.scss
@@ -2,4 +2,7 @@
     width: 1200px;
     margin: 0 auto;
     margin-bottom: 100px;
+    @media (max-width: 768px) {
+        width: 100%;
+      }
 }


### PR DESCRIPTION
## 작업 내용 리스트
- [x] 유저 이지미를 불러올때 빈 이미지 아이콘이 표시되는 이슈 해결
- [x] 로그인한 다른 유저도 모든 게시물, 댓글 삭제 및 수정하는 이슈 수정
- [x] 로그인 및 비로그인 유저 다시 확인하기
- [x] 커뮤니티 카드 리스트, 상세페이지, 글 추가/수정 영역 모바일 반응형 작업 완료 

## 이슈
* 타입스크립트 진행 중
* 코드 리팩토링 진행 X
* 연속 댓글 게시 후 한 게시물의 삭제 버튼을 클릭하면 모든 리스트 초기화 됨
* 대댓글 등록시 유저 이미지 변경이 새로고침을 해야 반영됨

## 추가 작업 예정
- [ ] 대댓글 스냅샷으로 다시 불러오도록 변경
- [ ] 게시물 카드 배너 이미지 추가 기능 넣기
- [ ] 카드리스트 아이템 댓글수(댓글수 + 대댓글수) 표시
- [ ] 상세페이지 ‘좋아요’와 '뷰' React-Query로 변경하여 헤더 Count 반영
- [ ] 게시글 카드 썸네일 사진 추가 기능 → 파이어스토어 용량 관련 회의
- [ ] 게시글 내부 이미지 업로드는 회의 진행해보기 → 파이어스토어 용량 관련 회의
- [ ] 스켈레톤 애니메이션 작업 → 기훈님이 추가한 스켈레톤 참고
- [ ] 로딩스피너 애니메이션 작업

## 참조자료
![20240205-깃허브_첨부이미지](https://github.com/side-project-pokehub/my-pokemon/assets/106785596/d5368403-560d-429c-bffc-04d7a898ac38)

